### PR TITLE
Now pmx shows the open ports of each app as a probe.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var Events      = require('./events.js');
 var Actions     = require('./actions.js');
 var Notify      = require('./notify.js');
 var Transaction = require('./transaction.js');
+var Network     = require('./network.js');
 var Monitor     = require('./monitor.js');
 
 var Probe       = require('./Probe.js');
@@ -23,6 +24,7 @@ util._extend(Export, Monitor);
 util._extend(Export, Pm2Module);
 util._extend(Export, Probe);
 util._extend(Export, Transaction);
+util._extend(Export, Network);
 
 Export.init = function(opts) {
   if (!opts) opts = {};
@@ -36,6 +38,7 @@ Export.init = function(opts) {
     custom_probes : true
   }, opts);
 
+  Export.catchPorts();
   Export.http(opts);
   Export.catchAll(opts);
   if (opts.custom_probes) {

--- a/lib/network.js
+++ b/lib/network.js
@@ -15,9 +15,15 @@ Network.catchPorts = function() {
   var original_listen = net_module.Server.prototype.listen;
 
   net_module.Server.prototype.listen = function() {
+    var port = parseInt(arguments[0]);
 
-    ports_list.push(parseInt(arguments[0]));
+    ports_list.push(port);
     opened_ports = ports_list.sort().join();
+
+    this.once('close', function() {
+      ports_list.splice(ports_list.indexOf(port), 1);
+      opened_ports = ports_list.sort().join();
+    });
 
     return original_listen.apply(this, arguments);
   };

--- a/lib/network.js
+++ b/lib/network.js
@@ -5,10 +5,10 @@ var Network = module.exports = {};
 
 Network.catchPorts = function() {
   var ports_list = [];
-  var opened_ports = 'none';
+  var opened_ports = 'N/A';
 
   Probe.probe().metric({
-    name    : 'Ports open',
+    name    : 'Open ports',
     value   : function() { return opened_ports; }
   });
 
@@ -19,6 +19,6 @@ Network.catchPorts = function() {
     ports_list.push(parseInt(arguments[0]));
     opened_ports = ports_list.sort().join();
 
-    original_listen.call(this, arguments);
+    return original_listen.apply(this, arguments);
   };
 };

--- a/lib/network.js
+++ b/lib/network.js
@@ -17,12 +17,16 @@ Network.catchPorts = function() {
   net_module.Server.prototype.listen = function() {
     var port = parseInt(arguments[0]);
 
-    ports_list.push(port);
-    opened_ports = ports_list.sort().join();
+    if (!isNaN(port)) {
+      ports_list.push(port);
+      opened_ports = ports_list.sort().join();
+    }
 
     this.once('close', function() {
-      ports_list.splice(ports_list.indexOf(port), 1);
-      opened_ports = ports_list.sort().join();
+      if (ports_list.indexOf(port) > -1) {
+        ports_list.splice(ports_list.indexOf(port), 1);
+        opened_ports = ports_list.sort().join();
+      }
     });
 
     return original_listen.apply(this, arguments);

--- a/lib/network.js
+++ b/lib/network.js
@@ -1,0 +1,24 @@
+var net_module = require('net');
+var Probe      = require('./Probe.js');
+
+var Network = module.exports = {};
+
+Network.catchPorts = function() {
+  var ports_list = [];
+  var opened_ports = 'none';
+
+  Probe.probe().metric({
+    name    : 'Ports open',
+    value   : function() { return opened_ports; }
+  });
+
+  var original_listen = net_module.Server.prototype.listen;
+
+  net_module.Server.prototype.listen = function() {
+
+    ports_list.push(parseInt(arguments[0]));
+    opened_ports = ports_list.sort().join();
+
+    original_listen.call(this, arguments);
+  };
+};

--- a/lib/network.js
+++ b/lib/network.js
@@ -17,7 +17,7 @@ Network.catchPorts = function() {
   net_module.Server.prototype.listen = function() {
     var port = parseInt(arguments[0]);
 
-    if (!isNaN(port)) {
+    if (!isNaN(port) && ports_list.indexOf(port) === -1) {
       ports_list.push(port);
       opened_ports = ports_list.sort().join();
     }

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -64,8 +64,6 @@ Transaction.http = function(opts) {
   });
 };
 
-
-
 // Transaction.patch = function() {
 //   var Module = require('module');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pmx",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Keymetrics++ and PM2 adapter",
   "main": "index.js",
   "dependencies" : {


### PR DESCRIPTION
Basically we overload the .listen() function of net.js to catch the ports and then put a listener for 'close' event (which is fired when the server is closed manually or has crashed) so we can remove the port from our list when this one is no longer being used.

PS : Tests for this feature will be implemented on PM2 directly for more ease.

![ports-pm2](https://cloud.githubusercontent.com/assets/7647602/7477669/a7a2c30e-f355-11e4-85d1-00d817c0719c.png)
![ports-km](https://cloud.githubusercontent.com/assets/7647602/7477674/afe1e248-f355-11e4-8399-063a9a3ba38a.png)
