### PR TITLE
Rename the class to be consistent with filename abbreviation

### DIFF
--- a/lib/utils/EWMA.js
+++ b/lib/utils/EWMA.js
@@ -3,9 +3,9 @@
 
 var units = require('./units');
 
-module.exports = ExponentiallyMovingWeightedAverage;
+module.exports = ExponentiallyWeightedMovingAverage;
 
-function ExponentiallyMovingWeightedAverage(timePeriod, tickInterval) {
+function ExponentiallyWeightedMovingAverage(timePeriod, tickInterval) {
   this._timePeriod   = timePeriod || 1 * units.MINUTE;
   this._tickInterval = tickInterval || ExponentiallyMovingWeightedAverage.TICK_INTERVAL;
   this._alpha        = 1 - Math.exp(-this._tickInterval / this._timePeriod);
@@ -13,19 +13,19 @@ function ExponentiallyMovingWeightedAverage(timePeriod, tickInterval) {
   this._rate         = 0;
 };
 
-ExponentiallyMovingWeightedAverage.TICK_INTERVAL = 5 * units.SECONDS;
+ExponentiallyWeightedMovingAverage.TICK_INTERVAL = 5 * units.SECONDS;
 
-ExponentiallyMovingWeightedAverage.prototype.update = function(n) {
+ExponentiallyWeightedMovingAverage.prototype.update = function(n) {
   this._count += n;
 };
 
-ExponentiallyMovingWeightedAverage.prototype.tick = function() {
+ExponentiallyWeightedMovingAverage.prototype.tick = function() {
   var instantRate = this._count / this._tickInterval;
   this._count     = 0;
 
   this._rate += (this._alpha * (instantRate - this._rate));
 };
 
-ExponentiallyMovingWeightedAverage.prototype.rate = function(timeUnit) {
+ExponentiallyWeightedMovingAverage.prototype.rate = function(timeUnit) {
   return (this._rate || 0) * timeUnit;
 };


### PR DESCRIPTION
The class inside EWMA was called ExponentiallyMovingWeightedAverage, which is inconsistent.  Rename...