### PR TITLE
Don't mess with incoming error

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -97,6 +97,8 @@ Notify.expressErrorHandler = function() {
 
   return function errorHandler(err, req, res, next) {
     if (res.statusCode < 400) res.statusCode = 500;
+    
+    err = Object.create(err);
 
     //debug(err.stack || err);
 


### PR DESCRIPTION
This method shouldn't mess with the incoming error in case the server has another error handler after this one.

Current workaround:

    app.use(function (err, req, res, next) {
      // DO YOUR STUFF
      res.json(err);
      pmx.expressErrorHandler(err, req, res, function () {});
    });