### PR TITLE
Stop clearing main module's paths

### DIFF
--- a/lib/probes/profiling.js
+++ b/lib/probes/profiling.js
@@ -95,7 +95,7 @@ Profiling.exposeProfiling = function(pmx, profiler_path) {
  * Discover v8-profiler
  */
 Profiling.detectV8Profiler = function(cb) {
-  var require_paths = require.main.paths;
+  var require_paths = require.main.paths.slice();
 
   (function look_for_profiler(require_paths) {
     if (!require_paths[0])

--- a/test/fixtures/module/module.async.require.js
+++ b/test/fixtures/module/module.async.require.js
@@ -1,0 +1,11 @@
+var pmx = require('../../..');
+pmx.init();
+
+setTimeout(function() {
+    try {
+        require('express');
+        process.exit(0);
+    } catch (e) {
+        process.exit(1);
+    }
+}, 1000);

--- a/test/profiling.mocha.js
+++ b/test/profiling.mocha.js
@@ -4,6 +4,10 @@ var Profiling = require('../lib/probes/profiling.js');
 var should = require('should');
 var shelljs = require('shelljs');
 
+function fork() {
+  return require('child_process').fork(__dirname + '/fixtures/module/module.async.require.js', []);
+}
+
 describe('Profiling', function() {
   it('should have right properties', function(done) {
     pmx.should.have.property('v8Profiling');
@@ -11,6 +15,16 @@ describe('Profiling', function() {
     Profiling.should.have.property('exposeProfiling');
     Profiling.should.have.property('v8Profiling');
     done();
+  });
+
+  it("should not break 'require' if v8-profiler is not present", function(done) {
+    fork().on('exit', function(n) {
+        if (n) {
+            done(new Error("Process exited with a non-zero code"));
+        } else {
+            done();
+        }
+    });
   });
 
   it.skip('should return error as v8-profiler not present', function(done) {


### PR DESCRIPTION
Closes #34 and #56.

Without this fix, the following code fails with: `Error: Cannot find module 'express'`

```js
var pmx = require('pmx');
pmx.init();

setTimeout(function() {
    require('express');
}, 1000);
```

Happy to add a test case if you need it, wasn't sure where to put it.