### PR TITLE
- Initially suport es6 native modules

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -21,6 +21,8 @@ Options.configureModule = function(opts) {
 };
 
 function findPackageJson() {
+
+  require.main = require.main || {filename: './somefile.js'};
   var pkg_path = path.resolve(path.dirname(require.main.filename), 'package.json');
 
   try {

--- a/lib/probes/profiling.js
+++ b/lib/probes/profiling.js
@@ -96,6 +96,8 @@ Profiling.exposeProfiling = function(pmx, profiler_path) {
  * Discover v8-profiler
  */
 Profiling.detectV8Profiler = function(module_name, cb) {
+  require.main = require.main || {paths: ['./node_modules', '/node_modules']};
+
   var require_paths = require.main.paths.slice();
 
   (function look_for_profiler(require_paths) {


### PR DESCRIPTION
From node v8.8.1 we received unstable es6 modules support with flag `--experimental-modules`.
(more about it here: https://nodejs.org/api/esm.html)

Es6 modules has broken code which depends on commonJS module system. This pull request allows initially with some hacks support es6 modules. 

**Note:** this provides full backward compatibility with CommonJS project.
**Note:** I'd hope this will be included in next pmx release - while es6 modules are still experimental feature they are worse supporting right now.
I was not really sure where and how shall I pull request it. Hope dev branch was the right choice.
I created simple project for demonstrating es6 modules usage: https://github.com/vpotseluyko/test-es6-pm2