### PR TITLE
Avoid console windows popping up on Windows 10

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -7,6 +7,7 @@ var Dependencies = {};
 
 Dependencies.collect = function() {
   childProcess.execFile(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['ls', '--json', '--production'], {
+    windowsHide: true,
     maxBuffer: 1024 * 1024
   }, function (error, stdout, stderr) {
     if (error) {


### PR DESCRIPTION
Without this PR, when call pmx.init in a detached process, a black console window will be popped up on Windows 10.  This is caused by the child_process.execFile call in Dependencies.collect function in lib/dependencies.js.

This is also stopping Unitech/pm2#2182